### PR TITLE
First steps so we can publish it on Docker Hub

### DIFF
--- a/docker/aerius-database-build/Dockerfile
+++ b/docker/aerius-database-build/Dockerfile
@@ -1,37 +1,38 @@
-FROM aerius-database:latest
+FROM mdillon/postgis:11-alpine
 
-# Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
-ENV PGDATA /postgresdata
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
 
 RUN apk update && apk upgrade \
-    # add ruby dependencies
+    # add ruby dependencies + curl
     && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
-    libstdc++ tzdata bash ca-certificates \
-
-    # add git dependencies
-    && apk --no-cache add --virtual .git-deps git openssh \
-
+    libstdc++ tzdata bash ca-certificates curl \
+    \
     # disable generating documentation for (ruby)gems
     && echo 'gem: --no-document' > /etc/gemrc \
-
+    \
     # install needed (ruby)gems
     && gem install net-ssh -v 4.2.0 \
     && gem install net-sftp \
     && gem install clbustos-rtf \
     && ruby --version \
     && gem list \
-
+    \
     # fetch repo
-    && git --version \
-    && git clone 'https://github.com/aerius/aerius-database-build.git' \
-
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
     # create necessary common folders (required by aerius-database-build - but not used by us yet)
     && mkdir -p aerius-database-common/src/data/sql \
     && mkdir -p aerius-database-common/src/main/sql \
-
-    # image cleanup (removing unneeded '.git' directory in cloned repo directory)
-    && rm -rf aerius-database-build/.git \
-    && apk del .git-deps
+    \
+    # Remove chown commands as they slow startup way down, our permissions are okay from the start
+    && sed -i -e 's/^\(.*chown\)/#\1/' /usr/local/bin/docker-entrypoint.sh
 
 # Copy build-database.sh to the image - Dockerfiles that extend on this image
 #  can use it to build a database easily. See script for the requirements.

--- a/docker/aerius-database-build/build-database.sh
+++ b/docker/aerius-database-build/build-database.sh
@@ -15,6 +15,7 @@ set -e
 
 # default values if not set
 : ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
 
 # add git dependencies
 apk --no-cache add --virtual .git-deps git openssh
@@ -46,7 +47,7 @@ ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-
 su postgres -c 'pg_ctl start'
 
 # execute database build
-ruby ../../aerius-database-build/bin/Build.rb default settings.rb -v '#' -n "${DATABASE_NAME}"
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
 
 # make the image smaller by doing a VACUUM FULL ANALYZE
 su postgres -c "psql -U '${POSTGRES_USER}' -d '${DATABASE_NAME}' -c 'VACUUM FULL ANALYZE'"
@@ -54,6 +55,6 @@ su postgres -c "psql -U '${POSTGRES_USER}' -d '${DATABASE_NAME}' -c 'VACUUM FULL
 # stop PostgreSQL database cleanly
 su postgres -c 'pg_ctl stop'
 
-# image cleanup (removing unneeded db-data, '.git' directory in cloned repo directory and git dependencies)
-rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"/.git
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
 apk del .git-deps

--- a/docker/aerius-database/Dockerfile
+++ b/docker/aerius-database/Dockerfile
@@ -1,9 +1,0 @@
-FROM mdillon/postgis:11-alpine
-
-ENV POSTGRES_DB='postgres' \
-    POSTGRES_USER='aerius' \
-    POSTGRES_PASSWORD='aerius'
-
-# Remove chown commands as they slow startup way down, our permissions are okay from the start
-RUN sed -i -e 's/^\(.*chown\)/#\1/' /usr/local/bin/docker-entrypoint.sh
-


### PR DESCRIPTION
- Merge `aerius-database` Dockerfile with `aerius-database-build`.
It was a base image, but only `aerius-database-build` made use of it.
So merging it looks like the way to go.
- Allow defining which runscript to run when building the database.
It will default to `default` to maintain backwards compatibility.
It can be overriden by providing `DBRUNSCRIPT`.
- Remove git directory altogether.
It would contain the SFTP password and it would remain in the resulting DB image.
These is no risk of it being retained in a Docker layer.
This can also free up quite some space.
- Download `tarball` instead of using a `git clone` of aerius-database-build.
Needs less dependencies and less space.
- Add extra slashes on empty lines in RUN commands
Docker would give out a warning if you don't.