### PR TITLE
Improvements triggered by publishing on Docker Hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Ignore custom shell scripts used for building Docker images
-docker/**/*.sh

--- a/docker/10-2.5/Dockerfile
+++ b/docker/10-2.5/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:10-2.5-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/10-2.5/build-database.sh
+++ b/docker/10-2.5/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/10-3.0/Dockerfile
+++ b/docker/10-3.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:10-3.0-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/10-3.0/build-database.sh
+++ b/docker/10-3.0/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/11-2.5/Dockerfile
+++ b/docker/11-2.5/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:11-2.5-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/11-2.5/build-database.sh
+++ b/docker/11-2.5/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/11-3.0/Dockerfile
+++ b/docker/11-3.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:11-3.0-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/11-3.0/build-database.sh
+++ b/docker/11-3.0/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/12-2.5/Dockerfile
+++ b/docker/12-2.5/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:12-2.5-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/12-2.5/build-database.sh
+++ b/docker/12-2.5/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/12-3.0/Dockerfile
+++ b/docker/12-3.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:12-3.0-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/12-3.0/build-database.sh
+++ b/docker/12-3.0/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/9.5-2.5/Dockerfile
+++ b/docker/9.5-2.5/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:9.5-2.5-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/9.5-2.5/build-database.sh
+++ b/docker/9.5-2.5/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/9.5-3.0/Dockerfile
+++ b/docker/9.5-3.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:9.5-3.0-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/9.5-3.0/build-database.sh
+++ b/docker/9.5-3.0/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/9.6-2.5/Dockerfile
+++ b/docker/9.6-2.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:12-3.0-alpine
+FROM postgis/postgis:9.6-2.5-alpine
 
 ENV POSTGRES_DB='postgres' \
     POSTGRES_USER='aerius' \
@@ -7,9 +7,9 @@ ENV POSTGRES_DB='postgres' \
     PGDATA='/postgresdata'
 
 RUN apk update && apk upgrade \
-    # add ruby dependencies + curl
+    # add ruby dependencies + curl + inotify-tools
     && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
-    libstdc++ tzdata bash ca-certificates curl \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
     \
     # disable generating documentation for (ruby)gems
     && echo 'gem: --no-document' > /etc/gemrc \
@@ -29,10 +29,7 @@ RUN apk update && apk upgrade \
     \
     # create necessary common folders (required by aerius-database-build - but not used by us yet)
     && mkdir -p aerius-database-common/src/data/sql \
-    && mkdir -p aerius-database-common/src/main/sql \
-    \
-    # Remove chown commands as they slow startup way down, our permissions are okay from the start
-    && sed -i -e 's/^\(.*chown\)/#\1/' /usr/local/bin/docker-entrypoint.sh
+    && mkdir -p aerius-database-common/src/main/sql
 
 # Copy build-database.sh to the image - Dockerfiles that extend on this image
 #  can use it to build a database easily. See script for the requirements.

--- a/docker/9.6-2.5/build-database.sh
+++ b/docker/9.6-2.5/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/9.6-3.0/Dockerfile
+++ b/docker/9.6-3.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM postgis/postgis:9.6-3.0-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/9.6-3.0/build-database.sh
+++ b/docker/9.6-3.0/build-database.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+# validations
+: ${SFTP_READONLY_PASSWORD?'SFTP_READONLY_PASSWORD must be provided'}
+: ${GIT_USERNAME?'GIT_USERNAME must be provided'}
+: ${GIT_TOKEN?'GIT_TOKEN must be provided'}
+: ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
+: ${GIT_ORG?'GIT_ORG must be provided'}
+: ${GIT_REPOSITORY?'GIT_REPOSITORY must be provided'}
+: ${DBDATA_PATH?'DBDATA_PATH must be provided'}
+: ${DBSOURCE_PATH?'DBSOURCE_PATH must be provided'}
+: ${DATABASE_NAME?'DATABASE_NAME must be provided'}
+
+# default values if not set
+: ${DBCONFIG_PATH:=aerius-database-build-config/config}
+: ${DBRUNSCRIPT:=default}
+
+# add git dependencies
+apk --no-cache add --virtual .git-deps git openssh
+
+# Make our own PGDATA.
+# We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
+
+# fetch repo
+git --version
+git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+
+# create db-data folder for the repo
+mkdir -p "${DBDATA_PATH}"
+
+# configure repo with the readonly SFTP password given as argument
+echo "\$sftp_data_readonly_password = '${SFTP_READONLY_PASSWORD}'" > "${GIT_REPOSITORY}/${DBCONFIG_PATH}/AeriusSettings.User.rb"
+
+# sync db-data files we need
+cd "${GIT_REPOSITORY}/${DBSOURCE_PATH}/"
+ruby ../../aerius-database-build/bin/SyncDBData.rb settings.rb --from-sftp --to-local
+
+# initialize database
+# (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
+#  Run 'postgres' which will trigger the initialization and start the database, so we can start building the database.)
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# The database starts twice. First to set it up and a second time to simply start cleanly.
+# Wait for it to stop once. (Detect socket file being removed)
+inotifywait -e DELETE --include .s.PGSQL.5432 /var/run/postgresql/
+
+# Wait for the DB to finish starting up (the second time)
+while [[ ! -S /var/run/postgresql/.s.PGSQL.5432 ]]; do
+  sleep 0.5s
+done
+
+# execute database build
+ruby ../../aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" settings.rb -v '#' -n "${DATABASE_NAME}"
+
+# make the image smaller by doing a VACUUM FULL ANALYZE
+psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
+
+# stop PostgreSQL database cleanly
+kill %1
+
+# image cleanup (removing unneeded db-data, git directory and git dependencies)
+rm -rf /"${DBDATA_PATH}" "${GIT_REPOSITORY}"
+apk del .git-deps

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -1,0 +1,36 @@
+FROM postgis/postgis:%%POSTGRESQL_VERSION%%-%%POSTGIS_VERSION%%-alpine
+
+ENV POSTGRES_DB='postgres' \
+    POSTGRES_USER='aerius' \
+    POSTGRES_PASSWORD='aerius' \
+    # Points to our own PGDATA. We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
+    PGDATA='/postgresdata'
+
+RUN apk update && apk upgrade \
+    # add ruby dependencies + curl + inotify-tools
+    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    libstdc++ tzdata bash ca-certificates curl inotify-tools \
+    \
+    # disable generating documentation for (ruby)gems
+    && echo 'gem: --no-document' > /etc/gemrc \
+    \
+    # install needed (ruby)gems
+    && gem install net-ssh -v 4.2.0 \
+    && gem install net-sftp \
+    && gem install clbustos-rtf \
+    && ruby --version \
+    && gem list \
+    \
+    # fetch repo
+    && curl -L -o aerius-database-build.tar.gz 'https://api.github.com/repos/aerius/aerius-database-build/tarball/master' \
+    && tar xfz aerius-database-build.tar.gz \
+    && rm aerius-database-build.tar.gz \
+    && mv aerius-aerius-database-build-* aerius-database-build \
+    \
+    # create necessary common folders (required by aerius-database-build - but not used by us yet)
+    && mkdir -p aerius-database-common/src/data/sql \
+    && mkdir -p aerius-database-common/src/main/sql
+
+# Copy build-database.sh to the image - Dockerfiles that extend on this image
+#  can use it to build a database easily. See script for the requirements.
+COPY build-database.sh /

--- a/docker/build_images.sh
+++ b/docker/build_images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Loop through all
+while read DIRECTORY; do
+  VERSION=$(basename "${DIRECTORY}")
+  echo 'Building: '"${VERSION}"
+  docker build -t stikstofje/aerius-database-build:"${VERSION}" "${VERSION}/"
+done < <(find . -maxdepth 1 -type d -name '*-*.*')

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+declare POSTGRES_VERSIONS=(9.5 9.6 10 11 12)
+declare POSTGIS_VERSIONS=(2.5 3.0)
+
+for POSTGRES_VERSION in "${POSTGRES_VERSIONS[@]}"; do
+  for POSTGIS_VERSION in "${POSTGIS_VERSIONS[@]}"; do
+    echo "PostgreSQL: ${POSTGRES_VERSION} - PostGIS: ${POSTGIS_VERSION}"
+    VERSION="${POSTGRES_VERSION}-${POSTGIS_VERSION}"
+
+    # Create directory if it doesn't exist yet
+    if [[ ! -d "${VERSION}" ]]; then
+      mkdir "${VERSION}"
+    fi
+
+    # Copy over files and process templates
+    cp build-database.sh "${VERSION}/"
+    sed -e 's/%%POSTGRESQL_VERSION%%/'"${POSTGRES_VERSION}"'/g;' \
+        -e 's/%%POSTGIS_VERSION%%/'"${POSTGIS_VERSION}"'/g;' \
+        Dockerfile.template > "${VERSION}/Dockerfile"
+  done
+done


### PR DESCRIPTION
- Made use of templating for Docker image versions.
This is used by most Docker image maintainers to make it easier to maintain everything.
- Added support for `PostgreSQL` 12/9.5/9.6 and dropped support for 9.4.
12 is a new version that is being maintained and 9.4 is EOL.
- Added support for specific `PostGIS` versions.
Before we used the `PostGIS` versions as chosen by the maintainer.
Because `postgis/postgis` does maintain multiple `PostGIS` versions, we can also do this.
At this time we'll have 10 versions, for every combination of `PostgreSQL` version and `PostGIS` version the maintainer supports.
- Added update.sh and build_images.sh.
This makes maintaining the dockerfiles easier and allows for easily building images to push to Docker Hub.
Idea is to make use of the automatic build option of Docker Hub later on.
- Some more changes needed to properly use the new `postgis/postgis` image.

PostgreSQL versions we support: 9.5, 9.6, 10, 11, 12.
PostGIS versions we support: 2.5, 3.0.