### PR TITLE
Removed some ruby-packages from dockerfile template

### DIFF
--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -8,7 +8,7 @@ ENV POSTGRES_DB='postgres' \
 
 RUN apk update && apk upgrade \
     # add ruby dependencies + curl + inotify-tools
-    && apk --no-cache add ruby ruby-irb ruby-rake ruby-io-console ruby-bigdecimal ruby-json ruby-bundler \
+    && apk --no-cache add ruby ruby-rake ruby-bigdecimal ruby-bundler \
     libstdc++ tzdata bash ca-certificates inotify-tools \
     \
     # disable generating documentation for (ruby)gems


### PR DESCRIPTION
Packages no longer appear to be present in alpine, and tbh not sure if they were used anyway. Thought irb and json were standard, and not sure what io-console is supposed to do but don't see any `io/console` requires so don't think we need it if its not already part of core?

Note: no clue if this works, haven't tried this locally.