### PR TITLE
Add logic for logging git-hash of database-build- and modules in database.

### DIFF
--- a/bin/ScriptCommands.rb
+++ b/bin/ScriptCommands.rb
@@ -440,6 +440,8 @@ class ScriptCommands
     add_constant 'CURRENT_DATABASE_VERSION', get_version(), schema unless $version.nil?
     add_constant 'CURRENT_DATABASE_PRODUCT', $product.to_s, schema unless $product.nil?
     add_constant 'CURRENT_GIT_REVISION', Utility.get_git_hash, schema if !$vcs.nil? && $vcs == :git
+    add_constant 'DATABASE_MODULES_GIT_REVISION', Utility.get_git_hash_modules, schema if !$vcs.nil? && $vcs == :git
+    add_constant 'DATABASE_BUILD_GIT_REVISION', Utility.get_git_hash_build, schema if !$vcs.nil? && $vcs == :git
     add_constant 'CURRENT_SVN_REVISION', Utility.get_svn_head_revision, schema if !$vcs.nil? && $vcs == :svn
     add_constant 'CURRENT_DATABASE_BUILD_DATE', Time.now.strftime('%d-%m-%Y %H:%M:%S'), schema
     add_constant 'CURRENT_DATABASE_BUILD_USER', Etc.getlogin, schema rescue nil

--- a/bin/ScriptCommands.rb
+++ b/bin/ScriptCommands.rb
@@ -20,7 +20,7 @@ class ScriptCommands
   def set_database_name(database_name)
     database_name = database_name.to_s
     database_name = database_name.gsub('#', Utility.get_svn_head_revision) if database_name.include?('#') && $vcs == :svn
-    database_name = database_name.gsub('#', Utility.get_git_hash) if database_name.include?('#') && $vcs == :git
+    database_name = database_name.gsub('#', Utility.get_git_hash($product_sql_path)) if database_name.include?('#') && $vcs == :git
     $database_name = database_name
     $logger.writeln "Database name = #{$database_name}"
   end
@@ -41,7 +41,7 @@ class ScriptCommands
   def set_version(version)
     version = version.to_s
     version = version.gsub('#', Utility.get_svn_head_revision) if version.include?('#') && $vcs == :svn
-    version = version.gsub('#', Utility.get_git_hash) if version.include?('#') && $vcs == :git
+    version = version.gsub('#', Utility.get_git_hash($product_sql_path)) if version.include?('#') && $vcs == :git
     $version = version
     $logger.writeln "Version = #{$version}"
     set_database_name($database_name_prefix + '-' + $product.to_s + '-' + $version) if $database_name.nil?
@@ -439,14 +439,15 @@ class ScriptCommands
     add_constant 'CURRENT_DATABASE_NAME', get_database_name(), schema
     add_constant 'CURRENT_DATABASE_VERSION', get_version(), schema unless $version.nil?
     add_constant 'CURRENT_DATABASE_PRODUCT', $product.to_s, schema unless $product.nil?
-    add_constant 'CURRENT_GIT_REVISION', Utility.get_git_hash, schema if !$vcs.nil? && $vcs == :git
-    add_constant 'DATABASE_MODULES_GIT_REVISION', Utility.get_git_hash_modules, schema if !$vcs.nil? && $vcs == :git
-    add_constant 'DATABASE_BUILD_GIT_REVISION', Utility.get_git_hash_build, schema if !$vcs.nil? && $vcs == :git
+    add_constant 'CURRENT_GIT_REVISION', Utility.get_git_hash($product_sql_path), schema if !$vcs.nil? && $vcs == :git
+    add_constant 'DATABASE_MODULES_GIT_REVISION', Utility.get_git_hash($database_modules_sql_path), schema if !$vcs.nil? && $vcs == :git
+    add_constant 'DATABASE_BUILD_GIT_REVISION', Utility.get_git_hash($database_build_sql_path), schema if !$vcs.nil? && $vcs == :git
     add_constant 'CURRENT_SVN_REVISION', Utility.get_svn_head_revision, schema if !$vcs.nil? && $vcs == :svn
     add_constant 'CURRENT_DATABASE_BUILD_DATE', Time.now.strftime('%d-%m-%Y %H:%M:%S'), schema
     add_constant 'CURRENT_DATABASE_BUILD_USER', Etc.getlogin, schema rescue nil
     add_constant 'CURRENT_DATABASE_BUILD_NODE', Etc.uname[:nodename], schema rescue nil
     add_constant 'CURRENT_DATABASE_BUILD_VERSION', get_database_build_version(), schema
+    add_constant 'TEST', Utility.get_git_status($database_build_sql_path), schema if !$vcs.nil? && $vcs == :git
   end
 
   def cluster_tables

--- a/bin/ScriptCommands.rb
+++ b/bin/ScriptCommands.rb
@@ -445,8 +445,6 @@ class ScriptCommands
     add_constant 'CURRENT_DATABASE_VERSION', get_version(), schema unless $version.nil?
     add_constant 'CURRENT_DATABASE_PRODUCT', $product.to_s, schema unless $product.nil?
     add_constant 'CURRENT_GIT_REVISION', Utility.get_git_hash($product_sql_path), schema if !$vcs.nil? && $vcs == :git
-    add_constant 'DATABASE_MODULES_GIT_REVISION', Utility.get_git_hash($database_modules_sql_path), schema if !$vcs.nil? && $vcs == :git
-    add_constant 'DATABASE_BUILD_GIT_REVISION', Utility.get_git_hash($database_build_sql_path), schema if !$vcs.nil? && $vcs == :git
     add_constant 'CURRENT_SVN_REVISION', Utility.get_svn_head_revision, schema if !$vcs.nil? && $vcs == :svn
     add_constant 'CURRENT_DATABASE_BUILD_DATE', Time.now.strftime('%d-%m-%Y %H:%M:%S'), schema
     add_constant 'CURRENT_DATABASE_BUILD_USER', Etc.getlogin, schema rescue nil

--- a/bin/ScriptCommands.rb
+++ b/bin/ScriptCommands.rb
@@ -120,6 +120,11 @@ class ScriptCommands
     end
   end
 
+  def check_uncommited_code(repo)
+    $logger.writeln "Checking for uncommitted code in repo #{repo}..."
+    Utility.get_git_status(repo)
+  end  
+
   def clear_log
     $logger.clear
   end
@@ -447,7 +452,6 @@ class ScriptCommands
     add_constant 'CURRENT_DATABASE_BUILD_USER', Etc.getlogin, schema rescue nil
     add_constant 'CURRENT_DATABASE_BUILD_NODE', Etc.uname[:nodename], schema rescue nil
     add_constant 'CURRENT_DATABASE_BUILD_VERSION', get_database_build_version(), schema
-    add_constant 'TEST', Utility.get_git_status($database_build_sql_path), schema if !$vcs.nil? && $vcs == :git
   end
 
   def cluster_tables

--- a/bin/Utility.rb
+++ b/bin/Utility.rb
@@ -101,6 +101,51 @@ class Utility
     raise "Could not read GIT hash with command: #{cmd}"
   end
 
+
+ def self.get_git_hash_modules
+    raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
+    raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))
+
+    curr_dir = Dir.pwd
+    Dir.chdir($database_modules_sql_path)
+    cmd = "\"#{$git_bin_path}git\" log -1 --pretty=format:%h"
+    socket = IO.popen(cmd)
+    begin
+      if line = socket.gets then
+        line = line.strip
+        raise "Illegal git hash found: #{line}" if line.length > 10
+        return line
+      end
+    ensure
+      socket.close
+      Dir.chdir(curr_dir)
+    end
+    raise "Could not read GIT hash with command: #{cmd}"
+  end
+
+
+ def self.get_git_hash_build
+    raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
+    raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))
+
+    curr_dir = Dir.pwd
+    Dir.chdir($database_build_sql_path)
+    cmd = "\"#{$git_bin_path}git\" log -1 --pretty=format:%h"
+    socket = IO.popen(cmd)
+    begin
+      if line = socket.gets then
+        line = line.strip
+        raise "Illegal git hash found: #{line}" if line.length > 10
+        return line
+      end
+    ensure
+      socket.close
+      Dir.chdir(curr_dir)
+    end
+    raise "Could not read GIT hash with command: #{cmd}"
+  end
+
+
   def self.get_svn_head_revision
     raise 'SVN bin path not set ($svn_bin_path)' if $svn_bin_path.nil?
     raise "SVN bin path not found ($svn_bin_path = \"#{$svn_bin_path}\")" unless ((File.exist?($svn_bin_path) && File.directory?($svn_bin_path)) || ($svn_bin_path.empty?))

--- a/bin/Utility.rb
+++ b/bin/Utility.rb
@@ -80,7 +80,6 @@ class Utility
     return lines.last(lastnum).join("")
   end
 
-
   def self.get_git_status(gitpath)
     raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
     raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))

--- a/bin/Utility.rb
+++ b/bin/Utility.rb
@@ -80,12 +80,35 @@ class Utility
     return lines.last(lastnum).join("")
   end
 
-  def self.get_git_hash
+
+  def self.get_git_status(gitpath)
     raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
     raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))
 
     curr_dir = Dir.pwd
-    Dir.chdir($product_sql_path)
+    Dir.chdir(gitpath)
+    cmd = "\"#{$git_bin_path}git\" status -s"
+    socket = IO.popen(cmd)
+    begin
+      line = socket.gets
+      if line != nil
+        raise "Uncommitted code detected!: #{line}"
+        return line
+      else return
+      end
+    ensure
+      socket.close
+      Dir.chdir(curr_dir)
+    end
+    raise "Could not read GIT status with command: #{cmd}"
+  end
+
+  def self.get_git_hash(gitpath)
+    raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
+    raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))
+
+    curr_dir = Dir.pwd
+    Dir.chdir(gitpath)
     cmd = "\"#{$git_bin_path}git\" log -1 --pretty=format:%h"
     socket = IO.popen(cmd)
     begin
@@ -100,51 +123,6 @@ class Utility
     end
     raise "Could not read GIT hash with command: #{cmd}"
   end
-
-
- def self.get_git_hash_modules
-    raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
-    raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))
-
-    curr_dir = Dir.pwd
-    Dir.chdir($database_modules_sql_path)
-    cmd = "\"#{$git_bin_path}git\" log -1 --pretty=format:%h"
-    socket = IO.popen(cmd)
-    begin
-      if line = socket.gets then
-        line = line.strip
-        raise "Illegal git hash found: #{line}" if line.length > 10
-        return line
-      end
-    ensure
-      socket.close
-      Dir.chdir(curr_dir)
-    end
-    raise "Could not read GIT hash with command: #{cmd}"
-  end
-
-
- def self.get_git_hash_build
-    raise 'Git bin path not set ($git_bin_path)' if $git_bin_path.nil?
-    raise "Git bin path not found ($git_bin_path = \"#{$git_bin_path}\")" unless ((File.exist?($git_bin_path) && File.directory?($git_bin_path)) || ($git_bin_path.empty?))
-
-    curr_dir = Dir.pwd
-    Dir.chdir($database_build_sql_path)
-    cmd = "\"#{$git_bin_path}git\" log -1 --pretty=format:%h"
-    socket = IO.popen(cmd)
-    begin
-      if line = socket.gets then
-        line = line.strip
-        raise "Illegal git hash found: #{line}" if line.length > 10
-        return line
-      end
-    ensure
-      socket.close
-      Dir.chdir(curr_dir)
-    end
-    raise "Could not read GIT hash with command: #{cmd}"
-  end
-
 
   def self.get_svn_head_revision
     raise 'SVN bin path not set ($svn_bin_path)' if $svn_bin_path.nil?


### PR DESCRIPTION
Add functions specific for getting the git hash for database-build and database-modules to Utillity.rb and use those new functions for logging these git-hashes in the system.constants table by additions to the function add_build_constants.
For this functionality to work, the constants which state the correct paths of the database-build and database-modules must be added in the settings.rb file of the corresponding product (in this case Monitor). For this, a PR is made in the Monitor- repo: PR#754. 

It works, but maybe this can be solved more generically, so for now I added the label WIP.