### PR TITLE
Add new postgresql version 18

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -8,8 +8,8 @@ cd "${SCRIPT_DIR}"
 
 # Key is the PostgreSQL version and values are the PostGIS versions images are available for that PostgreSQL version.
 declare -A IMAGE_VERSIONS=(
-  [17]="3.5"
-  [15]="3.4"
+  [18]="3.6"
+  [17]="3.6"
 )
 
 # Read in current version of the script

--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ cd "${SCRIPT_DIR}"
 # Key is the PostgreSQL version and values are the PostGIS versions images are available for that PostgreSQL version.
 declare -A IMAGE_VERSIONS=(
   [18]="3.6"
-  [17]="3.6"
+  [17]="3.6 3.5"
 )
 
 # Read in current version of the script


### PR DESCRIPTION
Postgres 15 is still an option technically, but with switching to a new snapshot it seems like a good moment to drop it.

(originally wanted to just update 15 to also use 3.5 postgis as is done on the `_fixes` branches, but don't think we're using it anywhere anymore)