### PR TITLE
Pin external modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ Typical `AppSettings.rb` / `UserSettings.rb` assignments:
 
 Both modes write `$build_config.layout.dbdata_path` from `DBDATA_PATH` into `UserSettings.rb` under `DBCONFIG_PATH`.
 
+### Docker image as a local build host
+
+`/build-database.sh` is for reproducible product DB images and always uses `--flags clean`. Developers can also run the image only for Ruby + PostgreSQL and call `Build.rb` / `SyncDBData.rb` on mounted sources. Omit `--flags clean` to copy external modules from sibling checkouts (same as a host build).
+
+Mount the workspace parent so the product repo and external module repos are siblings (and include `.git` on the product tree — needed to find the product git root):
+
+```text
+/work/<product-repo>/
+/work/database-modules/    # sibling named after the repo basename
+```
+
+Example:
+
+```bash
+docker run --rm -it \
+  -v /path/to/git:/work \
+  aerius-database-build:<tag> \
+  ruby /aerius-database-build/bin/Build.rb default \
+    /work/<product>/path/to/settings.rb \
+    --database-name=local \
+    --version=local
+```
+
+Do not pass `--flags clean` unless you want pinned clones. The base image does not install `git`; non-clean materialization only needs the sibling directories on the volume.
+
 ## Build script
 
 ### Reproducible builds — git hashes and uncommitted state

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $common_module_versions = [
 | Mode | Externals come from |
 |------|---------------------|
 | Dev (default) | Copy from sibling checkouts of the product git root (local edits included; not forced to `git_reference`) |
-| Clean / Docker (`--flags clean`) | `git clone` + checkout each `git_reference` |
+| Clean (`--flags clean` / Docker) | `git clone` + checkout each `git_reference` |
 
 ```bash
 # Dev
@@ -106,7 +106,14 @@ Typical `AppSettings.rb` / `UserSettings.rb` assignments:
 
 ### Docker
 
-`docker/build-database.sh` always passes `--flags clean` to Sync and Build, installs `git` for external clones (even when product sources are `COPY`'d), and writes `$build_config.layout.dbdata_path` from `DBDATA_PATH` into `UserSettings.rb` under `DBCONFIG_PATH`.
+`docker/build-database.sh` always passes `--flags clean` (clone external modules at pinned `git_reference`) and installs `git` for that. Whether the product/`DBSOURCE` tree is cloned is separate:
+
+| `CLONE_DBSOURCE` | When | Product / `DBSOURCE` |
+|------------------|------|----------------------|
+| `false` | `DBSOURCE_PATH` directory present | Local COPY/mount |
+| `true` | directory missing | `git clone` product repo (`GIT_*`), then paths are prefixed with `GIT_REPOSITORY` |
+
+Both modes write `$build_config.layout.dbdata_path` from `DBDATA_PATH` into `UserSettings.rb` under `DBCONFIG_PATH`.
 
 ## Build script
 

--- a/README.md
+++ b/README.md
@@ -45,21 +45,59 @@ Layout path defaults (specified under `layout` in the `BuildConfig.rb`):
 | `product_sql_path` | `<source_path>/src/main/sql/<product>/` |
 | `product_data_path` | `<source_path>/src/data/sql/<product>/` |
 | `runscripts_path` | `<build_config_path>/scripts/` |
-| `common_sql_paths` / `common_data_paths` | Arrays of dirs that exist from the locations below |
+| `common_sql_paths` / `common_data_paths` | Arrays of dirs merged after `SettingsLoader.prepare!` (internal + external + builtin) |
+| `external_common_modules_file` | Optional path to a modules file (relative to product settings dir or absolute) |
 
 Common module locations (each type its own entry):
 
 - **Internal** (beside product source) — optional. Same parent as `<source_path>`: `modules/src/main/sql` and `modules/src/data/sql`.
-- **External** — optional. For now: fixed checkout name `database-modules` next to `database-build`, with fixed paths inside that repo: `source/modules/src/main/sql` and `source/modules/src/data/sql` (i.e. ` /database-modules/source/modules/src/{main,data}/sql`).
+- **External** — optional. Declared in a modules file via `layout.external_common_modules_file` (any HTTPS repo; sql/data paths inside each repo are fixed: `source/modules/src/{main,data}/sql`). Materialized under `<output.target_path>/externals/`.
 - **Builtin** (SQL only) — required. `database-build/common/src/main/sql`.
 
-The workspace root is the parent directory of the `database-build` checkout (sibling repos such as `database-modules` and `dbdata` live there).
+The workspace is the parent of the `database-build` checkout. Product repos, external module repos, and the `dbdata/` folder usually live there as siblings. Dev builds copy external modules from siblings of the **product** git root (normally the same workspace).
+
+### External modules file
+
+Set in product or App settings:
+
+```ruby
+$build_config.layout.external_common_modules_file = 'externals/modules.rb'
+```
+
+Modules file content (assigns `$build_config.session.common_module_versions` or `$common_module_versions`):
+
+```ruby
+$common_module_versions = [
+  {
+    # plain HTTPS only — credentials via GIT_USERNAME / GIT_TOKEN, never in this file
+    'git_repository' => 'https://github.com/aerius/database-modules.git',
+    'git_reference' => 'abc123def456',
+  },
+]
+```
+
+`SettingsLoader.prepare!` (Build / SyncDBData) materializes external common modules under `output.target_path/externals/`.
+
+| Mode | Externals come from |
+|------|---------------------|
+| Dev (default) | Copy from sibling checkouts of the product git root (local edits included; not forced to `git_reference`) |
+| Clean / Docker (`--flags clean`) | `git clone` + checkout each `git_reference` |
+
+```bash
+# Dev
+ruby bin/SyncDBData.rb path/to/settings.rb --to-local
+ruby bin/Build.rb default path/to/settings.rb --version '#'
+
+# Clean
+ruby bin/Build.rb default path/to/settings.rb --flags clean --version '#'
+```
 
 ### Overridable settings
 
 Typical `AppSettings.rb` / `UserSettings.rb` assignments:
 
 - `$build_config.layout.dbdata_path` (default `<workspace>/dbdata/`)
+- `$build_config.layout.external_common_modules_file`
 - `$build_config.postgres.name_prefix` (default `AERIUS`)
 - `$build_config.postgres.username` / `.password` (default `aerius`)
 - `$build_config.tools.https_data_path` / `.https_data_username` / `.https_data_password`
@@ -68,7 +106,7 @@ Typical `AppSettings.rb` / `UserSettings.rb` assignments:
 
 ### Docker
 
-`docker/build-database.sh` writes `$build_config.layout.dbdata_path` from `DBDATA_PATH` into `UserSettings.rb` under `DBCONFIG_PATH` (the `config/` directory), so the image does not depend on the workspace `dbdata/` convention.
+`docker/build-database.sh` always passes `--flags clean` to Sync and Build, installs `git` for external clones (even when product sources are `COPY`'d), and writes `$build_config.layout.dbdata_path` from `DBDATA_PATH` into `UserSettings.rb` under `DBCONFIG_PATH`.
 
 ## Build script
 
@@ -81,6 +119,8 @@ When your runscript calls `add_build_constants`, the build stores:
 - **CURRENT_BUILD_COMMON_MODULE_REPO_HASHES** — A JSON string with one entry per common module repository (from `$build_config.layout.common_sql_paths` / `$build_config.layout.common_data_paths`). Each entry has `repo_url`, `commit_hash`, `sql_paths` (array), `data_paths` (array), and `had_uncommitted_changes`. A repository can have multiple paths, so the path arrays can have more than one element. Paths are relative to the git repository root, not to the project settings file.
 
 - **CURRENT_BUILD_SCRIPT_HAD_UNCOMMITTED_CHANGES** — `'true'` if the product sql path repository, product data path repository, or any common module repository had uncommitted or untracked changes; `'false'` otherwise.
+
+- **CURRENT_BUILD_CLEAN_BUILD_USED** — `'true'` when the build was started with `--flags clean`; `'false'` otherwise.
 
 Example JSON stored in CURRENT_BUILD_COMMON_MODULE_REPO_HASHES:
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Set in product or App settings:
 $build_config.layout.external_common_modules_file = 'externals/modules.rb'
 ```
 
-Modules file content (assigns `$build_config.session.common_module_versions` or `$common_module_versions`):
+Modules file content (assigns `$build_config.session.common_module_versions`):
 
 ```ruby
-$common_module_versions = [
+$build_config.session.common_module_versions = [
   {
     # plain HTTPS only — credentials via GIT_USERNAME / GIT_TOKEN, never in this file
     'git_repository' => 'https://github.com/aerius/database-modules.git',

--- a/bin/Build.rb
+++ b/bin/Build.rb
@@ -58,9 +58,10 @@ display_help if opts.has_key?('--help')
 
 # Settings
 require 'SettingsLoader.rb'
-SettingsLoader.load_settings(
+SettingsLoader.prepare!(
   ARGV.size > 1 ? ARGV[1] : nil,
-  ARGV.size > 0 ? ARGV[0] : nil
+  ARGV.size > 0 ? ARGV[0] : nil,
+  build_flags: opts['--flags']
 )
 
 # Logger
@@ -84,14 +85,13 @@ opts.each do |option, argument|
     when '--database-name'; override_database_name = argument
     when '--version'; override_version = argument
     when '--dump-filename'; $build_config.session.dump_filetitle = argument
-    when '--flags'; argument.split(',').each{ |flag| $build_config.session.build_flags << flag.strip.downcase.to_sym }
     when '--hints'; $build_config.tools.hint_level = argument.to_i
     when '--help'; display_help
   end
 end
 
 $logger.hint_level = $build_config.tools.hint_level
-$logger.major_hint "You are running a very old depecrated Ruby version (#{RUBY_VERSION}); updating to latest version is recommended" if Utility.is_ruby_version_below('2.2.0')
+$logger.major_hint "You are running a very old deprecated Ruby version (#{RUBY_VERSION}); updating to latest version is recommended" if Utility.is_ruby_version_below('3.2.0')
 
 # ------------------------------------
 

--- a/bin/BuildConfig.rb
+++ b/bin/BuildConfig.rb
@@ -5,13 +5,14 @@ HINT_LEVEL_ALL = 2
 ##
 # Build settings and derived layout paths ($build_config), grouped for clarity.
 #
-# Call order (see SettingsLoader.load_settings):
+# Call order (see SettingsLoader.prepare!):
 #   1. BuildConfig.new_empty
 #   2. apply_defaults!                         — fill defaults on the empty config
 #   3. require product settings                — assign product / layout.* (overrides)
-#   4. finalize!(product_settings_dir:)        — load App/UserSettings, derive & validate paths
-#   5. optional runscript resolve              — after finalize (needs layout.runscripts_path)
-#   6. log!(logger)                            — optional; dump resolved config (Build.rb)
+#   4. finalize!(product_settings_dir:)        — load App/UserSettings, derive internal/builtin layout
+#   5. ExternalModules.ensure_prepared!        — materialize externals, merge common SQL/data paths
+#   6. optional runscript resolve              — after finalize (needs layout.runscripts_path)
+#   7. log!(logger)                            — optional; dump resolved config (Build.rb)
 #
 # Settings files assign into $build_config; overrides in steps 3–4 replace defaults from step 2.
 #
@@ -27,7 +28,8 @@ class BuildConfig
     :product_sql_path, :product_data_path,
     :common_sql_paths, :common_data_paths,
     :runscripts_path, :dbdata_path,
-    :app_settings_file, :user_settings_file
+    :app_settings_file, :user_settings_file,
+    :external_common_modules_file
   )
 
   Output = Struct.new(
@@ -48,11 +50,13 @@ class BuildConfig
 
   Session = Struct.new(
     :product_settings_file, :runscript_file,
-    :build_flags, :dump_filetitle
+    :build_flags, :dump_filetitle,
+    :common_module_versions
   )
 
   attr_accessor :product
   attr_reader :layout, :output, :postgres, :tools, :session
+  attr_reader :internal_common_sql_paths, :internal_common_data_paths
 
   def initialize(product, layout, output, postgres, tools, session)
     @product = product
@@ -61,16 +65,18 @@ class BuildConfig
     @postgres = postgres
     @tools = tools
     @session = session
+    @internal_common_sql_paths = []
+    @internal_common_data_paths = []
   end
 
   def self.new_empty
     new(
       nil,
-      Layout.new(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil),
+      Layout.new(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil),
       Output.new(nil, nil, nil, nil),
       Postgres.new(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil),
       Tools.new(nil, nil, nil, nil, nil, nil, nil),
-      Session.new(nil, nil, [], nil)
+      Session.new(nil, nil, [], nil, [])
     )
   end
 
@@ -154,22 +160,23 @@ class BuildConfig
     end
     layout.product_data_path = PathAssert.ensure_dir!(layout.product_data_path, 'product_data_path')
 
-    layout.common_sql_paths = [
-      PathConventions.internal_modules_sql(layout.source_path),
-      PathConventions.dir_if_exists(PathConventions.workspace_root, PathConventions::MODULES_REPO, PathConventions::MODULES_SQL_REL),
-      PathConventions.join(PathConventions.database_build_root, PathConventions::BUILTIN_COMMON_SQL_REL).fix_pathname
+    # Internal modules only here; externals come from the modules file + ExternalModules;
+    # merged common_*_paths are set by apply_common_module_paths! after materialize/restore.
+    @internal_common_sql_paths = [
+      PathConventions.internal_modules_sql(layout.source_path)
     ].compact
-    layout.common_sql_paths.map!.with_index { |path, idx|
-      PathAssert.ensure_dir!(path, "common_sql_paths[#{idx}]")
-    }
+    @internal_common_data_paths = [
+      PathConventions.internal_modules_data(layout.source_path)
+    ].compact
 
-    layout.common_data_paths = [
-      PathConventions.internal_modules_data(layout.source_path),
-      PathConventions.dir_if_exists(PathConventions.workspace_root, PathConventions::MODULES_REPO, PathConventions::MODULES_DATA_REL)
-    ].compact
-    layout.common_data_paths.map!.with_index { |path, idx|
-      PathAssert.ensure_dir!(path, "common_data_paths[#{idx}]")
-    }
+    if layout.external_common_modules_file.nil? || layout.external_common_modules_file.to_s.empty?
+      layout.external_common_modules_file = nil
+    else
+      layout.external_common_modules_file = PathAssert.ensure_file!(
+        PathConventions.expand_from(product_settings_dir, layout.external_common_modules_file),
+        'external_common_modules_file'
+      )
+    end
 
     layout.runscripts_path = PathAssert.ensure_dir!(
       PathConventions.join(layout.build_config_path, SCRIPTS_DIR),
@@ -194,6 +201,29 @@ class BuildConfig
     output.output_path = output.output_path.fix_pathname
     output.temp_path = output.temp_path.fix_pathname
     tools.git_bin_path = tools.git_bin_path.fix_pathname unless (tools.git_bin_path.nil? || tools.git_bin_path.empty?)
+
+    self
+  end
+
+  # Merge internal + external + builtin into layout.common_sql_paths / common_data_paths and validate.
+  def apply_common_module_paths!(external_sql_paths, external_data_paths)
+    builtin_sql = PathConventions.join(
+      PathConventions.database_build_root, PathConventions::BUILTIN_COMMON_SQL_REL
+    ).fix_pathname
+
+    layout.common_sql_paths = (
+      Array(@internal_common_sql_paths) + Array(external_sql_paths) + [builtin_sql]
+    ).map { |path| path.fix_pathname.chomp('/') }
+    layout.common_data_paths = (
+      Array(@internal_common_data_paths) + Array(external_data_paths)
+    ).map { |path| path.fix_pathname.chomp('/') }
+
+    layout.common_sql_paths.map!.with_index { |path, idx|
+      PathAssert.ensure_dir!(path, "common_sql_paths[#{idx}]")
+    }
+    layout.common_data_paths.map!.with_index { |path, idx|
+      PathAssert.ensure_dir!(path, "common_data_paths[#{idx}]")
+    }
 
     self
   end

--- a/bin/ExternalModules.rb
+++ b/bin/ExternalModules.rb
@@ -1,0 +1,134 @@
+require 'fileutils'
+require 'GitUtility.rb'
+require 'PathConventions.rb'
+
+##
+# Materialize pinned external common modules under output.target_path/<TARGET_DIRNAME>/.
+# Dev builds copy sibling checkouts; --flags clean clones each git_reference.
+#
+class ExternalModules
+
+  TARGET_DIRNAME = 'externals'
+
+  # Materialize externals and merge paths into $build_config.
+  def self.ensure_prepared!(logger: nil)
+    materialize!(logger)
+  end
+
+  #
+  # Private section
+  #
+  private
+
+  # Clone or copy each modules-file entry into the target tree, then apply merged common paths.
+  def self.materialize!(logger = nil)
+    clean_build = $build_config.session.build_flags.include?(:clean)
+    versions = Array($build_config.session.common_module_versions)
+    target_root = resolve_target_root_path
+    
+    external_sql_paths = []
+    external_data_paths = []
+
+    # Create target directory
+    FileUtils.mkdir_p(target_root)
+
+    # Resolve source root for dev builds
+    source_root = nil
+    if !versions.empty? && !clean_build then
+      source_root = resolve_source_root!
+    end
+
+    # Materialize each entry
+    deduped_entries(versions).each do |entry|
+      repo_url = entry.fetch('git_repository')
+      repo_key = repo_folder_basename(repo_url)
+
+      target_dir = File.join(target_root, repo_key).fix_pathname.chomp('/')
+
+      populate_target_dir!(target_dir, repo_url, entry['git_reference'], clean_build, source_root, logger)
+
+      external_sql_paths << File.join(target_dir, PathConventions::EXTERNAL_MODULES_SQL_REL).fix_pathname.chomp('/')
+      external_data_paths << File.join(target_dir, PathConventions::EXTERNAL_MODULES_DATA_REL).fix_pathname.chomp('/')
+    end
+
+    validate_materialized_paths!(external_sql_paths, external_data_paths)
+    $build_config.apply_common_module_paths!(external_sql_paths, external_data_paths)
+
+    unless logger.nil? then
+      logger.writeln "Prepared common modules at #{target_root}"
+      external_sql_paths.each { |path| logger.writeln "  common sql:  #{path}" }
+      external_data_paths.each { |path| logger.writeln "  common data: #{path}" }
+    end
+  end
+
+  def self.resolve_target_root_path
+    return File.expand_path(File.join($build_config.output.target_path, TARGET_DIRNAME)).fix_pathname
+  end
+
+  # Parent of the product git root: external repos are siblings of the product checkout.
+  def self.resolve_source_root!
+    product_sql = $build_config.layout.product_sql_path
+    product_root = GitUtility.get_git_repo_root(product_sql)
+    raise "Cannot derive external common modules source root: product SQL path is not in a git repository (product_sql_path = \"#{product_sql}\")" if product_root.nil? || product_root.to_s.empty?
+    source_root = File.expand_path(File.join(product_root, '..')).fix_pathname
+    raise "External common modules source root not found (\"#{source_root}\")" unless File.directory?(source_root)
+    return source_root
+  end
+
+  def self.deduped_entries(entries)
+    seen = {}
+    entries.each do |entry|
+      repo = entry.fetch('git_repository')
+      GitUtility.require_plain_https_repo_url!(repo)
+      if entry.key?('sql_path') || entry.key?('data_path') then
+        raise "External modules entry for '#{repo}' must not set sql_path/data_path; layout is fixed (#{PathConventions::EXTERNAL_MODULES_SQL_REL} / #{PathConventions::EXTERNAL_MODULES_DATA_REL})"
+      end
+      raise "Duplicate external modules entry for git_repository '#{repo}'" if seen.key?(repo)
+      seen[repo] = entry
+    end
+    return seen.values
+  end
+
+  # Extract the basename of a repository URL
+  def self.repo_folder_basename(repo_url)
+    return repo_url.to_s.sub(%r{/$}, '').sub(%r{\.git$}i, '').split('/').last
+  end
+
+  def self.populate_target_dir!(target_dir, repo_url, gitref, clean_build, source_root, logger)
+    if clean_build then
+      raise "External modules entry for '#{repo_url}' missing 'git_reference'" if gitref.nil? || gitref.to_s.empty?
+      
+      if File.directory?(target_dir) && GitUtility.ref_matches_path?(target_dir, gitref) then
+        logger.writeln "Reusing existing clone at '#{target_dir}' (#{gitref})" unless logger.nil?
+        return
+      end
+      
+      if File.directory?(target_dir) then
+        logger.writeln "Removing stale clone at '#{target_dir}'..." unless logger.nil?
+        FileUtils.rm_rf(target_dir)
+      end
+      
+      logger.writeln "Cloning '#{repo_url}' to '#{target_dir}' @ #{gitref}" unless logger.nil?
+      GitUtility.clone_and_checkout(repo_url, target_dir, gitref)
+    else
+      repo_key = repo_folder_basename(repo_url)
+      source_dir = File.join(source_root, repo_key).fix_pathname.chomp('/')
+      raise "External common module source not found (#{repo_key} = \"#{source_dir}\")" unless File.directory?(source_dir)
+
+      logger.writeln "Copying '#{source_dir}' to '#{target_dir}'" unless logger.nil?
+      FileUtils.rm_rf(target_dir) if File.exist?(target_dir)
+      FileUtils.mkdir_p(File.dirname(target_dir))
+      FileUtils.cp_r(source_dir, target_dir)
+    end
+  end
+
+  def self.validate_materialized_paths!(sql_paths, data_paths)
+    sql_paths.each_with_index { |path, idx|
+      raise "External common SQL path not found (#{idx}: \"#{path}\")" unless File.directory?(path)
+    }
+    data_paths.each_with_index { |path, idx|
+      raise "External common data path not found (#{idx}: \"#{path}\")" unless File.directory?(path)
+    }
+  end
+
+end

--- a/bin/GitUtility.rb
+++ b/bin/GitUtility.rb
@@ -1,3 +1,7 @@
+require 'fileutils'
+require 'uri'
+require 'Utility.rb'
+
 ##
 # Git-specific utility methods.
 #
@@ -45,10 +49,71 @@ class GitUtility
     return run_git(path, 'status --porcelain') != nil
   end
 
+  # Returns true if the repo at path is checked out at gitref (full or short hash).
+  def self.ref_matches_path?(path, gitref)
+    return false if path.nil? || !File.directory?(path) || gitref.nil? || gitref.to_s.empty?
+    current = get_git_hash_for_path(path)
+    return true if current == gitref
+    short = get_git_short_hash_for_path(path)
+    return true if short == gitref
+    return true if !current.nil? && current.start_with?(gitref.to_s)
+    return false
+  end
+
+  # Raises unless repo_url is a plain HTTPS URL (no SSH, no embedded credentials).
+  # Auth for private clones is only via GIT_USERNAME / GIT_TOKEN.
+  def self.require_plain_https_repo_url!(repo_url)
+    url = repo_url.to_s
+    raise "git_repository must be an HTTPS URL without credentials (got \"#{url}\")" unless url =~ %r{\Ahttps://}i
+    raise "git_repository must not include credentials; use GIT_USERNAME/GIT_TOKEN (got \"#{url}\")" if url =~ %r{\Ahttps://[^/]*@}i
+  end
+
+  # Clones repo_url into target_dir. Raises on failure.
+  # When GIT_USERNAME and GIT_TOKEN are set, HTTPS URLs are cloned with those credentials.
+  # The token is never written to command logs or left on remote.origin.url.
+  def self.clone_repo(repo_url, target_dir)
+    require_plain_https_repo_url!(repo_url)
+    parent = File.dirname(target_dir)
+    FileUtils.mkdir_p(parent)
+    raise "Git clone target already exists: '#{target_dir}'" if File.exist?(target_dir)
+    clone_url = authenticated_clone_url(repo_url)
+    # Avoid logging credentials embedded in the clone URL.
+    log_command = (clone_url == repo_url)
+    clone_cmd = "cd \"#{parent}\" && #{git_exe} clone --quiet \"#{clone_url}\" \"#{target_dir}\""
+    raise "Git clone failed for '#{repo_url}'" unless Utility.run_cmd(clone_cmd, log_command, "git clone #{repo_url}")
+    # Keep recorded remotes credential-free (hashes / CURRENT_BUILD_* constants).
+    if clone_url != repo_url then
+      set_url_cmd = "cd \"#{target_dir}\" && #{git_exe} remote set-url origin \"#{repo_url}\""
+      raise "Git remote set-url failed for '#{repo_url}'" unless Utility.run_cmd(set_url_cmd, true, "git remote set-url origin #{repo_url}")
+    end
+  end
+
+  # Checks out gitref in target_dir. Raises on failure.
+  def self.checkout_ref(target_dir, gitref)
+    raise "Git checkout target not found: '#{target_dir}'" unless File.directory?(target_dir)
+    checkout_cmd = "cd \"#{target_dir}\" && #{git_exe} checkout --quiet \"#{gitref}\""
+    raise "Git checkout failed for '#{gitref}' in '#{target_dir}'" unless Utility.run_cmd(checkout_cmd, true, "git checkout #{gitref}")
+  end
+
+  # Clones repo_url into target_dir and checks out gitref. Raises on failure.
+  def self.clone_and_checkout(repo_url, target_dir, gitref)
+    clone_repo(repo_url, target_dir)
+    checkout_ref(target_dir, gitref)
+  end
+
   #
   # Private section
   #
   private
+
+  # Returns repo_url with GIT_USERNAME:GIT_TOKEN embedded when both env vars are set.
+  # Caller must pass a plain HTTPS URL (see require_plain_https_repo_url!).
+  def self.authenticated_clone_url(repo_url)
+    username = ENV['GIT_USERNAME'].to_s
+    token = ENV['GIT_TOKEN'].to_s
+    return repo_url if username.empty? || token.empty?
+    return repo_url.sub(%r{\Ahttps://}i, "https://#{URI.encode_uri_component(username)}:#{URI.encode_uri_component(token)}@")
+  end
 
   # Git executable for shell invocation: PATH name or quoted path when git bin path is set.
   def self.git_exe

--- a/bin/GitUtility.rb
+++ b/bin/GitUtility.rb
@@ -30,8 +30,11 @@ class GitUtility
   end
 
   # Returns git repo root for path, or nil.
+  # Prefers `git rev-parse`; if git is unavailable, walks parents for a `.git` entry.
   def self.get_git_repo_root(path)
-    return run_git(path, 'rev-parse --show-toplevel')
+    root = run_git(path, 'rev-parse --show-toplevel')
+    return root unless root.nil? || root.to_s.empty?
+    return find_git_repo_root_by_dot_git(path)
   end
 
   # Returns full git commit hash for the repo containing path, or nil.
@@ -144,6 +147,20 @@ class GitUtility
   rescue
     Dir.chdir(curr_dir) if defined?(curr_dir) && Dir.pwd != curr_dir
     return nil
+  end
+
+  # Walk parents of path looking for a `.git` entry; return that directory or nil.
+  def self.find_git_repo_root_by_dot_git(path)
+    return nil if path.nil? || path.to_s.empty?
+    start = File.exist?(path) ? (File.directory?(path) ? path : File.dirname(path)) : nil
+    return nil if start.nil?
+    dir = File.expand_path(start)
+    loop do
+      return dir.fix_pathname.chomp('/') if File.exist?(File.join(dir, '.git'))
+      parent = File.expand_path('..', dir)
+      return nil if parent == dir
+      dir = parent
+    end
   end
 
 end

--- a/bin/PathConventions.rb
+++ b/bin/PathConventions.rb
@@ -6,18 +6,16 @@ module PathConventions
   DATA_REL = 'src/data/sql'
   MODULES_DIR = 'modules'
   DBDATA_DIR = 'dbdata'
-  MODULES_REPO = 'database-modules'
-  # Sibling modules repo: <workspace>/database-modules/source/modules/src/{main,data}/sql
-  MODULES_SQL_REL = 'source/modules/src/main/sql'
-  MODULES_DATA_REL = 'source/modules/src/data/sql'
   BUILTIN_COMMON_SQL_REL = 'common/src/main/sql'
+  EXTERNAL_MODULES_SQL_REL = 'source/modules/src/main/sql'
+  EXTERNAL_MODULES_DATA_REL = 'source/modules/src/data/sql'
 
   # database-build checkout root (parent of bin/)
   def self.database_build_root
     File.expand_path('..', File.dirname($0))
   end
 
-  # Parent of database-build (workspace containing sibling repos)
+  # Parent of database-build (workspace: sibling repo checkouts and dbdata/ folder)
   def self.workspace_root
     File.expand_path('..', database_build_root)
   end

--- a/bin/ScriptCommands.rb
+++ b/bin/ScriptCommands.rb
@@ -141,7 +141,6 @@ class ScriptCommands
         $logger.error "Unknown parameter given to import_database_structure()"
       end
 
-      bullet = Utility.is_ruby_version_below('1.9.0') ? 250.chr : "\u00B7".force_encoding('UTF-8')
       print ' ['
       Dir[$build_config.layout.product_sql_path + '**/*.sql'].sort.each { |sql_filename|
         if as_is then
@@ -150,7 +149,7 @@ class ScriptCommands
           contents = PostgresTools.process_sql_file(sql_filename, $build_config.layout.common_sql_paths)
           PostgresTools.execute_sql_command(contents, sql_filename) unless contents.empty?
         end
-        print bullet
+        print "\u00B7"
       }
       print ']'
     }
@@ -452,6 +451,7 @@ class ScriptCommands
     add_constant 'CURRENT_DATABASE_BUILD_VERSION', get_database_build_version(), schema
     add_constant 'CURRENT_BUILD_COMMON_MODULE_REPO_HASHES', CommonModulesUtility.build_repo_hashes($build_config.layout.common_sql_paths, $build_config.layout.common_data_paths), schema
     add_constant 'CURRENT_BUILD_SCRIPT_HAD_UNCOMMITTED_CHANGES', (CommonModulesUtility.any_had_uncommitted_changes?($build_config.layout.product_sql_path, $build_config.layout.product_data_path, $build_config.layout.common_sql_paths, $build_config.layout.common_data_paths) ? 'true' : 'false'), schema
+    add_constant 'CURRENT_BUILD_CLEAN_BUILD_USED', ($build_config.session.build_flags.include?(:clean) ? 'true' : 'false'), schema
   end
 
   def cluster_tables

--- a/bin/ScriptRunner.rb
+++ b/bin/ScriptRunner.rb
@@ -8,8 +8,7 @@ class ScriptRunner
   @@script_commands = ScriptCommands.new
 
   def method_missing(method_sym, *arguments)
-    # Note: In Ruby 1.8 the 'methods' array below contains Strings, in 1.9 it contains Symbols.
-    if @@script_commands.methods.include?(method_sym) || @@script_commands.methods.include?(method_sym.to_s) then # only public methods
+    if @@script_commands.methods.include?(method_sym) then # only public methods
       @@script_commands.send(method_sym, *arguments)
     else
       super

--- a/bin/SettingsLoader.rb
+++ b/bin/SettingsLoader.rb
@@ -92,7 +92,7 @@ class SettingsLoader
   end
 
   # Load optional layout.external_common_modules_file into session.common_module_versions.
-  # Modules files may assign $build_config.session.common_module_versions or $common_module_versions.
+  # Modules files must assign $build_config.session.common_module_versions.
   def self.load_external_modules_file!
     path = $build_config.layout.external_common_modules_file
     if path.nil? || path.to_s.empty? then
@@ -100,14 +100,8 @@ class SettingsLoader
       return
     end
 
-    $common_module_versions = nil
     require path
-
-    versions = $build_config.session.common_module_versions
-    if (versions.nil? || (versions.respond_to?(:empty?) && versions.empty?)) && !$common_module_versions.nil? then
-      versions = $common_module_versions
-    end
-    $build_config.session.common_module_versions = Array(versions)
+    $build_config.session.common_module_versions = Array($build_config.session.common_module_versions)
   end
 
 end

--- a/bin/SettingsLoader.rb
+++ b/bin/SettingsLoader.rb
@@ -3,21 +3,23 @@ require 'PathConventions.rb'
 require 'PathAssert.rb'
 require 'GitUtility.rb'
 require 'BuildConfig.rb'
+require 'ExternalModules.rb'
 
 # Single process handle for build settings (groups: layout, output, postgres, tools, session)
 $build_config = nil
 
 ##
-# CLI bootstrap for $build_config: resolve ARGV paths, require product settings, finalize.
-# App/User settings are loaded inside BuildConfig#finalize!.
+# CLI bootstrap for $build_config: resolve ARGV paths, require product settings, finalize,
+# materialize external common modules. App/User settings are loaded inside BuildConfig#finalize!.
 #
 class SettingsLoader
 
-  # Load product settings into $build_config and finalize. If runscript_file_argument is
-  # given, resolve it after finalize (needs layout.runscripts_path).
-  def self.load_settings(product_settings_file_argument, runscript_file_argument = nil)
+  # Prepare $build_config for Build / Sync: load settings, materialize or restore externals.
+  # build_flags may be nil, a comma-separated String, or an Array (must include :clean for clean/Docker).
+  def self.prepare!(product_settings_file_argument, runscript_file_argument = nil, build_flags: [])
     $build_config = BuildConfig.new_empty
     $build_config.apply_defaults!
+    $build_config.session.build_flags = parse_build_flags(build_flags)
 
     # Product settings (mandatory) — assign $build_config.product / layout.*
     product_settings_file = determine_product_settings_file(product_settings_file_argument)
@@ -26,13 +28,32 @@ class SettingsLoader
 
     $build_config.finalize!(product_settings_dir: File.dirname(product_settings_file))
 
+    load_external_modules_file!
+    ExternalModules.ensure_prepared!(logger: nil)
+
     determine_runscript_file(runscript_file_argument) unless runscript_file_argument.nil?
+  end
+
+  # Accepts nil, a comma-separated String, or an Array of flags/symbols.
+  def self.parse_build_flags(flags_argument)
+    return [] if flags_argument.nil?
+    parts = flags_argument.is_a?(String) ? flags_argument.split(',') : Array(flags_argument)
+    normalize_build_flags(parts)
   end
 
   #
   # Private section
   #
   private
+
+  def self.normalize_build_flags(build_flags)
+    flags = []
+    Array(build_flags).each do |flag|
+      sym = flag.to_s.strip.downcase.to_sym
+      flags << sym unless sym.to_s.empty? || flags.include?(sym)
+    end
+    flags
+  end
 
   # Expand path_argument; if not a file, try appending each suffix in order.
   # Returns the first existing non-directory path, or the expanded path if none match.
@@ -68,6 +89,25 @@ class SettingsLoader
 
     # Cannot live in BuildConfig#finalize!: ARGV runscript is resolved here after finalize,
     $build_config.session.runscript_file = PathAssert.ensure_file!(runscript_file, 'runscript_file')
+  end
+
+  # Load optional layout.external_common_modules_file into session.common_module_versions.
+  # Modules files may assign $build_config.session.common_module_versions or $common_module_versions.
+  def self.load_external_modules_file!
+    path = $build_config.layout.external_common_modules_file
+    if path.nil? || path.to_s.empty? then
+      $build_config.session.common_module_versions = []
+      return
+    end
+
+    $common_module_versions = nil
+    require path
+
+    versions = $build_config.session.common_module_versions
+    if (versions.nil? || (versions.respond_to?(:empty?) && versions.empty?)) && !$common_module_versions.nil? then
+      versions = $common_module_versions
+    end
+    $build_config.session.common_module_versions = Array(versions)
   end
 
 end

--- a/bin/SyncDBData.rb
+++ b/bin/SyncDBData.rb
@@ -28,30 +28,32 @@ def display_help
   puts "     --from-https     Sync from $https_data HTTPS. Supply HTTPS url if different from default"
   puts "  -l --to-local       Sync to local db-data folder. Supply path if different from default"
   puts "  -c --continue       Continue on file not found errors"
+  puts "     --flags          Comma separated list of build flags (e.g. clean)"
   puts "  -i --info           Displays defaults path (does not run)"
   puts "  -h --help           This help"
   puts ""
   exit
 end
 
-$opts = {}
+opts = {}
 GetoptLong.new(
     ['--path', '-p', GetoptLong::REQUIRED_ARGUMENT],
     ['--from-https', GetoptLong::OPTIONAL_ARGUMENT],
     ['--from-local', '-f', GetoptLong::OPTIONAL_ARGUMENT],
     ['--to-local', '-l', GetoptLong::OPTIONAL_ARGUMENT],
+    ['--flags', GetoptLong::REQUIRED_ARGUMENT],
     ['--continue', '-c', GetoptLong::NO_ARGUMENT],
     ['--info', '-i', GetoptLong::NO_ARGUMENT],
     ['--help', '-h', GetoptLong::NO_ARGUMENT]
-).each { |option, argument| $opts[option.downcase] = argument }
+).each { |option, argument| opts[option.downcase] = argument }
 
-display_help if $opts.has_key?('--help')
+display_help if opts.has_key?('--help')
 
 # ------------------------------------
 
-# Settings
+# Settings (flags before prepare! for clean vs dev materialization)
 require 'SettingsLoader.rb'
-SettingsLoader.load_settings(ARGV.size > 0 ? ARGV[0] : nil)
+SettingsLoader.prepare!(ARGV.size > 0 ? ARGV[0] : nil, build_flags: opts['--flags'])
 
 # Logger
 require 'BuildLogger.rb'
@@ -85,8 +87,8 @@ def display_info
   exit
 end
 
-def parse_commandline
-  $opts.each do |option, argument|
+def parse_commandline(opts)
+  opts.each do |option, argument|
     case option.downcase
       when '--path'
         $build_config.layout.product_data_path = File.expand_path(argument.to_s).fix_pathname
@@ -110,7 +112,7 @@ def parse_commandline
     end
   end
 
-  display_info if $opts.has_key?('--info')
+  display_info if opts.has_key?('--info')
 
   if $source == :https then
     $logger.writeln "Syncing from HTTPS (#{$from_https})"
@@ -322,7 +324,7 @@ end
 
 # ---------
 
-parse_commandline
+parse_commandline(opts)
 
 $datasources = DataSourceCollector.collect($logger, $build_config.layout.product_data_path, $build_config.layout.common_data_paths, nil).keys
 

--- a/docker/build-database.sh
+++ b/docker/build-database.sh
@@ -37,8 +37,8 @@ else
    : ${DATABASE_VERSION?'DATABASE_VERSION must be set if source code is present locally..'}
 fi
 
-# add git dependencies if needed
-[[ ${USE_GIT} ]] && apk --no-cache add --virtual .git-deps git openssh
+# git is needed to clone the product repo (when USE_GIT) and always for clean external-module clones
+apk --no-cache add --virtual .git-deps git openssh
 
 # Make our own PGDATA.
 # We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
@@ -58,13 +58,16 @@ echo "\$build_config.layout.dbdata_path = '${DBDATA_PATH}'" >> "${DBCONFIG_PATH}
 [[ -n "${HTTPS_DATA_USERNAME}" ]] && echo "\$build_config.tools.https_data_username = '${HTTPS_DATA_USERNAME}'" >> "${DBCONFIG_PATH}/UserSettings.rb"
 [[ -n "${HTTPS_DATA_PASSWORD}" ]] && echo "\$build_config.tools.https_data_password = '${HTTPS_DATA_PASSWORD}'" >> "${DBCONFIG_PATH}/UserSettings.rb"
 
-# Set git support off in the build script
-! [[ ${USE_GIT} ]] && echo "\$build_config.tools.git_bin_path = nil" >> "${DBCONFIG_PATH}/UserSettings.rb"
+# Docker always uses clean build for external common modules (clone at pinned gitref).
+BUILD_FLAG_ARGS=(--flags clean)
 
 # sync db-data files we need
 echo 'Syncing database data files..'
 cd "${DBSOURCE_PATH}/"
-ruby /aerius-database-build/bin/SyncDBData.rb "${DBSETTINGS_BASE_DIRECTORY}/${DBSETTINGS_PATH}" --to-local
+ruby /aerius-database-build/bin/SyncDBData.rb \
+  "${DBSETTINGS_BASE_DIRECTORY}/${DBSETTINGS_PATH}" \
+  --to-local \
+  "${BUILD_FLAG_ARGS[@]}"
 
 # initialize database
 # (this is a wrapper provided by the postgres image, which will initialize the db if it isn't already and is executed when starting the image for the first time.
@@ -84,7 +87,12 @@ done
 echo 'PostgreSQL is up again'
 
 # execute database build
-ruby /aerius-database-build/bin/Build.rb "${DBRUNSCRIPT}" "${DBSETTINGS_BASE_DIRECTORY}/${DBSETTINGS_PATH}" -v "${DATABASE_VERSION}" -n "${DATABASE_NAME}"
+ruby /aerius-database-build/bin/Build.rb \
+  "${DBRUNSCRIPT}" \
+  "${DBSETTINGS_BASE_DIRECTORY}/${DBSETTINGS_PATH}" \
+  -v "${DATABASE_VERSION}" \
+  -n "${DATABASE_NAME}" \
+  "${BUILD_FLAG_ARGS[@]}"
 
 # make the image smaller by doing a VACUUM FULL ANALYZE
 psql -U "${POSTGRES_USER}" -d "${DATABASE_NAME}" -c 'VACUUM FULL ANALYZE'
@@ -107,8 +115,7 @@ if [[ "${DBDATA_CLEANUP}" == 'true' ]]; then
   rm -rf "${DBDATA_PATH}"
 fi
 [[ ${USE_GIT} ]] && rm -rf "${GIT_REPOSITORY}"
-[[ ${USE_GIT} ]] && apk del .git-deps
-
+apk del .git-deps
 # Exit with 0 if this stage is reached, otherwise the return code from
 #  the last if statement might be used, which might let Docker think the build failed
 exit 0

--- a/docker/build-database.sh
+++ b/docker/build-database.sh
@@ -14,14 +14,17 @@ set -e
 : ${DBSETTINGS_PATH:=settings.rb}
 : ${DBDATA_CLEANUP:=true} # A reason not to clean it up would be to cache the files using buildkit
 
-# If the source code isn't made available by the extending Dockerfile we need to use git to check it out
-USE_GIT=! [[ -d "${DBSOURCE_PATH}" ]]
-
-[[ ${USE_GIT} ]] && echo 'Source code present in GIT..'
-! [[ ${USE_GIT} ]] && echo 'Source code present locally..'
+# If the source code isn't made available by the extending Dockerfile we need to clone it.
+if [[ -d "${DBSOURCE_PATH}" ]]; then
+  CLONE_DBSOURCE=false
+  echo 'Source code present locally..'
+else
+  CLONE_DBSOURCE=true
+  echo 'Source code present in GIT..'
+fi
 
 # Do git specific validations and fix paths if needed
-if [[ ${USE_GIT} ]]; then
+if [[ "${CLONE_DBSOURCE}" == true ]]; then
   : ${GIT_USERNAME?'GIT_USERNAME must be provided'}
   : ${GIT_TOKEN?'GIT_TOKEN must be provided'}
   : ${GIT_HOSTNAME?'GIT_HOSTNAME must be provided'}
@@ -34,19 +37,20 @@ if [[ ${USE_GIT} ]]; then
   DBCONFIG_PATH="${GIT_REPOSITORY}/${DBCONFIG_PATH}"
 else
   # We require a version outside of git
-   : ${DATABASE_VERSION?'DATABASE_VERSION must be set if source code is present locally..'}
+  : ${DATABASE_VERSION?'DATABASE_VERSION must be set if source code is present locally..'}
 fi
 
-# git is needed to clone the product repo (when USE_GIT) and always for clean external-module clones
+# Install git and ssh
 apk --no-cache add --virtual .git-deps git openssh
+git --version
+ssh -V
 
 # Make our own PGDATA.
 # We are unfortunately doing this because we want the data to persist but the default PGDATA directory is marked as a volume, which cannot be undone.
 mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}" && chmod 777 "${PGDATA}"
 
 # fetch repo if needed
-[[ ${USE_GIT} ]] && git --version
-[[ ${USE_GIT} ]] && git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
+[[ "${CLONE_DBSOURCE}" == true ]] && git clone "https://${GIT_USERNAME}:${GIT_TOKEN}@${GIT_HOSTNAME}/${GIT_ORG}/${GIT_REPOSITORY}.git"
 
 # create db-data folder for the repo
 mkdir -p "${DBDATA_PATH}"
@@ -110,11 +114,9 @@ else
   pg_resetwal --pgdata "${PGDATA}"
 fi
 
-# image cleanup (removing unneeded db-data, git directory and git dependencies)
-if [[ "${DBDATA_CLEANUP}" == 'true' ]]; then
-  rm -rf "${DBDATA_PATH}"
-fi
-[[ ${USE_GIT} ]] && rm -rf "${GIT_REPOSITORY}"
+# Image cleanup (removing unneeded db-data, git directory and git dependencies)
+[[ "${DBDATA_CLEANUP}" == 'true' ]] && rm -rf "${DBDATA_PATH}"
+[[ "${CLONE_DBSOURCE}" == true ]] && rm -rf "${GIT_REPOSITORY}"
 apk del .git-deps
 # Exit with 0 if this stage is reached, otherwise the return code from
 #  the last if statement might be used, which might let Docker think the build failed


### PR DESCRIPTION
- Pin external common modules from a modules file; materialize under `target/externals/` (sibling copy in dev, `git clone` at pin with `--flags clean` / Docker)
- Fix Docker product-source cloning (`CLONE_DBSOURCE`); Docker builds always clean-clone externals
- Document using the image as a local `Build.rb` host with volume-mounted sources